### PR TITLE
chore: promote python-flask-docker2 to version 0.0.4

### DIFF
--- a/config-root/namespaces/jx-production/python-flask-docker2/python-flask-docker2-0.0.4-release.yaml
+++ b/config-root/namespaces/jx-production/python-flask-docker2/python-flask-docker2-0.0.4-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-16T01:20:33Z"
+  creationTimestamp: "2021-03-16T02:22:26Z"
   deletionTimestamp: null
-  name: 'python-flask-docker2-0.0.1'
+  name: 'python-flask-docker2-0.0.4'
   namespace: jx-production
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.1
-      sha: fa5a55fe12f2fdd9dcd5951a36bc0b3b1bf44bc6
+        chore: release 0.0.4
+      sha: 5a0bb08a3e91cbc08a3ba65a5a8d0175e5718d66
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,21 +29,20 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: a3ae7cf4d8d808c97304d8262988f325bfea92ff
+      sha: 2650207befda3398849dd20d22c48759d30933fb
     - author:
         email: lexarflash8g@gmail.com
-        name: lexarflash8g
+        name: Lexar_flash
       branch: master
       committer:
-        email: lexarflash8g@gmail.com
-        name: lexarflash8g
-      message: |
-        chore: Jenkins X build pack
-      sha: df2fa45403108a1c641a2f73b9aecc37cb7f37e8
+        email: noreply@github.com
+        name: GitHub
+      message: Update build_docker.yml
+      sha: dfb9f195617b81848a8425b04407176edf5e14d9
   gitHttpUrl: https://github.com/lexarflash8g/python-flask-docker2
   gitOwner: lexarflash8g
   gitRepository: python-flask-docker2
   name: 'python-flask-docker2'
-  releaseNotesURL: https://github.com/lexarflash8g/python-flask-docker2/releases/tag/v0.0.1
-  version: v0.0.1
+  releaseNotesURL: https://github.com/lexarflash8g/python-flask-docker2/releases/tag/v0.0.4
+  version: v0.0.4
 status: {}

--- a/config-root/namespaces/jx-production/python-flask-docker2/python-flask-docker2-python-flask-docker2-deploy.yaml
+++ b/config-root/namespaces/jx-production/python-flask-docker2/python-flask-docker2-python-flask-docker2-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: python-flask-docker2-python-flask-docker2
   labels:
     draft: draft-app
-    chart: "python-flask-docker2-0.0.1"
+    chart: "python-flask-docker2-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: python-flask-docker2-python-flask-docker2
       containers:
         - name: python-flask-docker2
-          image: "130405883059.dkr.ecr.us-west-1.amazonaws.com/lexarflash8g/python-flask-docker2:0.0.1"
+          image: "130405883059.dkr.ecr.us-west-1.amazonaws.com/lexarflash8g/python-flask-docker2:0.0.4"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.1
+              value: 0.0.4
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-production/python-flask-docker2/python-flask-docker2-svc.yaml
+++ b/config-root/namespaces/jx-production/python-flask-docker2/python-flask-docker2-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: python-flask-docker2
   labels:
-    chart: "python-flask-docker2-0.0.1"
+    chart: "python-flask-docker2-0.0.4"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-production
 spec:

--- a/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-u2cqm-pod.yaml
+++ b/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-u2cqm-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-y7pfx"
+  name: "jenkins-ui-test-u2cqm"
   namespace: myjenkins
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-production/helmfile.yaml
+++ b/helmfiles/jx-production/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/python-flask-docker2
-  version: 0.0.1
+  version: 0.0.4
   name: python-flask-docker2
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote python-flask-docker2 to version 0.0.4

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
