### PR TITLE
chore: promote python-flask-docker2 to version 0.0.5

### DIFF
--- a/config-root/namespaces/jx-staging/python-flask-docker2/python-flask-docker2-0.0.5-release.yaml
+++ b/config-root/namespaces/jx-staging/python-flask-docker2/python-flask-docker2-0.0.5-release.yaml
@@ -2,9 +2,9 @@
 apiVersion: jenkins.io/v1
 kind: Release
 metadata:
-  creationTimestamp: "2021-03-16T02:22:26Z"
+  creationTimestamp: "2021-03-16T02:27:11Z"
   deletionTimestamp: null
-  name: 'python-flask-docker2-0.0.4'
+  name: 'python-flask-docker2-0.0.5'
   namespace: jx-staging
   labels:
     gitops.jenkins-x.io/pipeline: 'namespaces'
@@ -18,8 +18,8 @@ spec:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
       message: |
-        chore: release 0.0.4
-      sha: 5a0bb08a3e91cbc08a3ba65a5a8d0175e5718d66
+        chore: release 0.0.5
+      sha: df72a19db7d72a5f6a9894c499bc99c741e89ba2
     - author:
         email: jenkins-x@googlegroups.com
         name: jenkins-x-bot
@@ -29,7 +29,7 @@ spec:
         name: jenkins-x-bot
       message: |
         chore: add variables
-      sha: 2650207befda3398849dd20d22c48759d30933fb
+      sha: cd65e16f2e1cd7b6fa76811327a0d4d1914aaf9b
     - author:
         email: lexarflash8g@gmail.com
         name: Lexar_flash
@@ -38,11 +38,11 @@ spec:
         email: noreply@github.com
         name: GitHub
       message: Update build_docker.yml
-      sha: dfb9f195617b81848a8425b04407176edf5e14d9
+      sha: 75e7df0cb5113ecc942afb8a6b55ec0e0c5f2ae5
   gitHttpUrl: https://github.com/lexarflash8g/python-flask-docker2
   gitOwner: lexarflash8g
   gitRepository: python-flask-docker2
   name: 'python-flask-docker2'
-  releaseNotesURL: https://github.com/lexarflash8g/python-flask-docker2/releases/tag/v0.0.4
-  version: v0.0.4
+  releaseNotesURL: https://github.com/lexarflash8g/python-flask-docker2/releases/tag/v0.0.5
+  version: v0.0.5
 status: {}

--- a/config-root/namespaces/jx-staging/python-flask-docker2/python-flask-docker2-python-flask-docker2-deploy.yaml
+++ b/config-root/namespaces/jx-staging/python-flask-docker2/python-flask-docker2-python-flask-docker2-deploy.yaml
@@ -5,7 +5,7 @@ metadata:
   name: python-flask-docker2-python-flask-docker2
   labels:
     draft: draft-app
-    chart: "python-flask-docker2-0.0.4"
+    chart: "python-flask-docker2-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
   annotations:
@@ -24,11 +24,11 @@ spec:
       serviceAccountName: python-flask-docker2-python-flask-docker2
       containers:
         - name: python-flask-docker2
-          image: "130405883059.dkr.ecr.us-west-1.amazonaws.com/lexarflash8g/python-flask-docker2:0.0.4"
+          image: "130405883059.dkr.ecr.us-west-1.amazonaws.com/lexarflash8g/python-flask-docker2:0.0.5"
           imagePullPolicy: IfNotPresent
           env:
             - name: VERSION
-              value: 0.0.4
+              value: 0.0.5
           envFrom: null
           ports:
             - name: http

--- a/config-root/namespaces/jx-staging/python-flask-docker2/python-flask-docker2-svc.yaml
+++ b/config-root/namespaces/jx-staging/python-flask-docker2/python-flask-docker2-svc.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   name: python-flask-docker2
   labels:
-    chart: "python-flask-docker2-0.0.4"
+    chart: "python-flask-docker2-0.0.5"
     gitops.jenkins-x.io/pipeline: 'namespaces'
   namespace: jx-staging
 spec:

--- a/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-lmyb7-pod.yaml
+++ b/config-root/namespaces/myjenkins/jenkins/templates/tests/jenkins-ui-test-lmyb7-pod.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "jenkins-ui-test-mky7n"
+  name: "jenkins-ui-test-lmyb7"
   namespace: myjenkins
   annotations:
     "helm.sh/hook": test-success

--- a/helmfiles/jx-staging/helmfile.yaml
+++ b/helmfiles/jx-staging/helmfile.yaml
@@ -9,7 +9,7 @@ repositories:
   url: http://jenkins-x-chartmuseum.jx.svc.cluster.local:8080
 releases:
 - chart: dev/python-flask-docker2
-  version: 0.0.4
+  version: 0.0.5
   name: python-flask-docker2
   values:
   - jx-values.yaml


### PR DESCRIPTION
chore: promote python-flask-docker2 to version 0.0.5

this commit will trigger a pipeline to [generate the actual kubernetes resources to perform the promotion](https://jenkins-x.io/docs/v3/about/how-it-works/#promotion) which will create a second commit on this Pull Request before it can merge
